### PR TITLE
Break if a page resolves back to itself repeatedly

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,21 @@ it('uses any data passed as a second argument to fill out the form', () => {
       assert.equal(name, 'David HasselHoff');
     });
 });
+
+it('saves screenshots of errors to specified screenshot location', () => {
+  const inputs = {};
+  return browser.goto('/confirm', inputs, { screenshots: '/path/to/output/dir' });
+});
+
+it('tries a pre-specified number of times to get past stuck loops', () => {
+  const inputs = {};
+  return browser.goto('/confirm', inputs, { maxLoops: 1 });
+});
 ```
+
+## Options
+
+Options are passed as a third argument to the exposed method. The following options are available:
+
+* `maxLoops` - determines how many times a step will retry if it resolves back to itself on submission before failing. Default: `3`
+* `screenshots` - specifies a location to save screenshots of the page when it gets stuck. If not specified then no screenshots are saved.

--- a/lib/autofill.js
+++ b/lib/autofill.js
@@ -6,9 +6,17 @@ const Inputs = require('./inputs');
 
 const debug = require('debug')('hof:util:autofill');
 
-module.exports = (browser) => (target, input) => {
+const MAX_LOOPS = 3;
+
+module.exports = (browser) => (target, input, options) => {
+
+  options = options || {};
+  options.maxLoops = options.maxLoops || MAX_LOOPS;
 
   const getValue = Inputs(input);
+
+  let last;
+  let count = 0;
 
   function completeTextField(element, name) {
     const value = getValue(name, 'text');
@@ -116,6 +124,12 @@ module.exports = (browser) => (target, input) => {
         });
       })
       .then(() => {
+        if (options.screenshots) {
+          const screenshot = require('path').resolve(options.screenshots, 'hof-autofill.pre-submit.png');
+          return browser.saveScreenshot(screenshot);
+        }
+      })
+      .then(() => {
         debug('Submitting form');
         return browser.submitForm('form');
       })
@@ -125,6 +139,25 @@ module.exports = (browser) => (target, input) => {
             u = url.parse(u);
             debug(`New page is: ${u.path}`);
             if (u.path !== path) {
+              debug(`Checking current path ${u.path} against last path ${last}`);
+              if (last === u.path) {
+                count++;
+                debug(`Stuck on path ${u.path} for ${count} iterations`);
+                if (count === options.maxLoops) {
+                  if (options.screenshots) {
+                    const screenshot = require('path').resolve(options.screenshots, 'hof-autofill.debug.png');
+                    return browser.saveScreenshot(screenshot)
+                      .then(() => {
+                        throw new Error(`Progress stuck at ${u.path} - screenshot saved to ${screenshot}`);
+                      });
+                  } else {
+                    throw new Error(`Progress stuck at ${u.path}`);
+                  }
+                }
+              } else {
+                count = 0;
+              }
+              last = u.path;
               return completeStep(path);
             }
             debug(`Arrived at ${path}. Done.`);


### PR DESCRIPTION
Stop filling out and throw an error if a page keeps resolving to itself. That is, it has irreconcilable validation errors.