### PR TITLE
Ignore invisible text fields

### DIFF
--- a/lib/autofill.js
+++ b/lib/autofill.js
@@ -12,8 +12,14 @@ module.exports = (browser) => (target, input) => {
 
   function completeTextField(element, name) {
     const value = getValue(name, 'text');
-    debug(`Filling field: ${element} with value: ${value}`);
-    return browser.elementIdValue(element, value);
+    debug(`Filling field: ${name} with value: ${value}`);
+    return browser
+      .elementIdClear(element)
+      .elementIdValue(element, value)
+      .catch((e) => {
+        // any error here is *probably* because the field is hidden
+        // ignore and hope for the best
+      });
   }
 
   function completeRadio(element, name) {


### PR DESCRIPTION
Fields which are only displayed when other radio/checkbox fields are selected should not throw errors when failing to fill them out.

It's easier to just swallow the error than to check visibility first.