### PR TITLE
Allow functions returning values to be passed to auto-filler

### DIFF
--- a/lib/inputs.js
+++ b/lib/inputs.js
@@ -33,6 +33,9 @@ module.exports = input => {
 
   return (name, type) => {
     const value = input[name] || getDefault(name, type);
+    if (typeof value === 'function') {
+      return value();
+    }
     if (value && type === 'checkbox') {
       return [].concat(value);
     }


### PR DESCRIPTION
When the test might want to provide dynamic values for a field allow a function to be passed.

In particular when a field is hit twice in a loop than we can provide a function that returns different values each time.