### PR TITLE
Add page content debug when form filler gets stuck

### DIFF
--- a/lib/autofill.js
+++ b/lib/autofill.js
@@ -190,6 +190,18 @@ module.exports = (browser) => (target, input, options) => {
             }
             debug(`Arrived at ${path}. Done.`);
           });
+      })
+      .catch(e => {
+        return browser.getText('#content')
+          .then(text => {
+            debug('PAGE CONTENT >>>>>>');
+            debug(text);
+            debug('END PAGE CONTENT >>>>>>');
+          })
+          .catch(err => null)
+          .then(() => {
+            throw e;
+          })
       });
   }
 


### PR DESCRIPTION
When an error occurs in a CI environment it can be difficult to isolate the exact cause of the error. Add debug information with the page content when an autofill fails to help debug the issue.