### PR TITLE
Prevent webdriver deprecation warnings

### DIFF
--- a/lib/autofill.js
+++ b/lib/autofill.js
@@ -159,7 +159,7 @@ module.exports = (browser) => (target, input, options) => {
       })
       .then(() => {
         debug('Submitting form');
-        return browser.submitForm('form');
+        return browser.$('input[type="submit"]').click();
       })
       .then(() => {
         return browser.getUrl()


### PR DESCRIPTION
Webdriver emits a deprecation warning every time `submitForm` is called, which is super noisy. Replacing `submitForm` with `$('input[type="submit"]').click()` is functionally equivalent, but doesn't emit the warning.